### PR TITLE
Add python_requires 2.7 or 3.6+ to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,14 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     url="https://github.com/andrzejnovak/mplhep/",
+    classifiers=[
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=['matplotlib>=3.1.0', 'requests>=2.21.0'],
     packages=['mplhep'],
     # cmdclass          = {'install': PostInstallCommand}, # Currently disabled


### PR DESCRIPTION
This will make it clear to PyPI what Python requires are needed and also make it clear to the user when they try to install it.

This PR also adds classifier metadata for PyPI.