### PR TITLE
Use PEP 440/508 compatible release syntax in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
-    install_requires=['matplotlib>=3.1.0', 'requests>=2.21.0'],
+    install_requires=['matplotlib~=3.1', 'requests~=2.21'],
     packages=['mplhep'],
     # cmdclass          = {'install': PostInstallCommand}, # Currently disabled
     include_package_data=True)


### PR DESCRIPTION
To ensure stable APIs while not pinning at specific versions use PEP 440/508's compatible release syntax for the library dependencies to pin them at their current major release version while allowing for minor version updates.

This also has the nice feature of being able to intentionally choose when to update to a dependency's newer API even if the dependency has had a new major release with API breaking changes for a long time.

Noting that if the release is specified down to the bug fix release (`X.Y.Z`) then it will be pinned down to the minor release (`X.Y`). c.f. [PEP 404](https://www.python.org/dev/peps/pep-0440/#compatible-release):

>  the following groups of version clauses are equivalent:
> ```
> ~= 1.4.5
> >= 1.4.5, == 1.4.*
> ```

so as updates from other libraries are desirable, as long as there is no API breaking changes, then all dependencies should be specified as

```
~= X.Y
```

unless they need to be specified all the way down to `X.Y.*`

c.f.
- https://www.python.org/dev/peps/pep-0440/#compatible-release
- https://www.python.org/dev/peps/pep-0508