### PR TITLE
Use sys instead of six in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 from setuptools.command.install import install
+import sys
 
-import six
-
-INSTALL_REQUIRES = ['matplotlib<3' if six.PY2 else 'matplotlib~=3.1',
-                    'requests~=2.21',
-                    ]
+INSTALL_REQUIRES = [
+    'matplotlib<3' if sys.version_info.major < 3 else 'matplotlib~=3.1',
+    'requests~=2.21',
+]
 
 
 class PostInstallCommand(install):


### PR DESCRIPTION
Resolves #3 

Using `sys.version_info.major` allows setup.py to determine the version of the Python runtime that is installing mplhep without the use of six (which is outside of the standard library). This allows mplhep to be installed in an empty virtual environment, which is strongly desired.

If this is accepted then a new patch release should be cut and published to PyPI.