### PR TITLE
Add extra_requires environments to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ script:
 - pytest --mpl
 
 install:
-- pip -q install --upgrade setuptools setuptools_scm
-- pip -q install matplotlib scipy pytest flake8 pytest-mpl --upgrade
-- pip -q install .
+- python -m pip install -q --upgrade pip setuptools wheel setuptools_scm
+- python -m pip install -q --no-cache-dir -e .[complete]
 
 
 deploy:

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,12 @@ INSTALL_REQUIRES = [
     'requests~=2.21',
 ]
 
+extras_require = {
+    'test': ['pytest', 'pytest-mpl'],
+    'develop': ['flake8', 'twine'],
+}
+extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
+
 
 class PostInstallCommand(install):
     # Currently disabled, done on the fly
@@ -52,6 +58,7 @@ setup(
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=INSTALL_REQUIRES,
+    extras_require=extras_require,
     # packages=find_packages(exclude=['tests']),
     # cmdclass= {'install': PostInstallCommand}, # Currently disabled
     packages=['mplhep'],


### PR DESCRIPTION
Moving `extras_require` to `setup.py` gives greater reproducibility as it explicitly defines within the library itself what is development requirements are. This also makes it easier to test in CI systems.