### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI/CD
+
+on:
+  push:
+  pull_request:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install -q --no-cache-dir -e .[complete]
+        python -m pip list
+    - name: Lint with flake8
+      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
+      run: |
+        flake8 mplhep
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx --mpl

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 os:
 - linux
 python:
-- 3.6
 - 3.7
 - 2.7
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
   <img src="https://raw.githubusercontent.com/andrzejnovak/mplhep/master/img/mplhep.png" width="300"/>
 </p>
 
-[![Build Status](https://travis-ci.org/andrzejnovak/mplhep.svg?branch=master)](https://travis-ci.org/andrzejnovak/mplhep) ![Hits](https://countimports.pythonanywhere.com/nocount/tag.svg?url=count_mplhep_imports)
+[![Build Status](https://travis-ci.org/andrzejnovak/mplhep.svg?branch=master)](https://travis-ci.org/andrzejnovak/mplhep)
+[![GitHub Actions Status: CI](https://github.com/andrzejnovak/mplhep/workflows/CI/CD/badge.svg)](https://github.com/andrzejnovak/mplhep/actions?query=workflow%3ACI%2FCD+branch%3Amaster)
+![Hits](https://countimports.pythonanywhere.com/nocount/tag.svg?url=count_mplhep_imports)
 
 [![PyPI version](https://badge.fury.io/py/mplhep.svg)](https://badge.fury.io/py/mplhep)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/mplhep.svg)](https://pypi.org/project/mplhep/)


### PR DESCRIPTION
Use GitHub Actions to add CI for Python 3 on Ubuntu and MacOS that runs on push events, pull requests, and every day as a CRON job at 0:01 UTC. Additionally, add a GitHub Actions CI badge to the `README`. This keeps Travis CI for deployment for the time being.