### PR TITLE
Add Binder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![GitHub Actions Status: CI](https://github.com/andrzejnovak/mplhep/workflows/CI/CD/badge.svg)](https://github.com/andrzejnovak/mplhep/actions?query=workflow%3ACI%2FCD+branch%3Amaster)
 ![Hits](https://countimports.pythonanywhere.com/nocount/tag.svg?url=count_mplhep_imports)
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/andrzejnovak/mplhep/master)
+
 [![PyPI version](https://badge.fury.io/py/mplhep.svg)](https://badge.fury.io/py/mplhep)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/mplhep.svg)](https://pypi.org/project/mplhep/)
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,1 @@
+python -m pip install --upgrade .[complete]


### PR DESCRIPTION
Add [Binder](https://mybinder.org/) support by using the [`postBuild`](https://mybinder.readthedocs.io/en/latest/config_files.html#postbuild-run-code-after-installing-the-environment) configuration file to install `mplhep` from the local repo. Additionally add a Binder launch badge to the `README`.

Binder allows users to run interactively in their browser inside a Jupyter Hub environment. So people can demo `mplhep` and run the example Jupyter notebook without installing.